### PR TITLE
adding CFLAGS, CPPFLAGS and LDFLAGS to Makefile

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -68,15 +68,15 @@ CPP_DEPS += \
 ./utils.d
 
 %.o: %.cpp
-	$(CP) -O3 -g3 -c -fmessage-length=0 $(OPENMP) -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o $@ $(SRC_DIR)$<
+	$(CP) $(CPPFLAGS) $(LDFLAGS) -O3 -g3 -c -fmessage-length=0 $(OPENMP) -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o $@ $(SRC_DIR)$<
 
 %.o: %.c
-	$(CC) -O3 -g3 -c -fmessage-length=0 $(OPENMP) -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o $@ $<
+	$(CC) $(CFLAGS) $(LDFLAGS) -O3 -g3 -c -fmessage-length=0 $(OPENMP) -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o $@ $<
 
 all: treePL
 
 treePL: $(OBJS)
-	$(CP) -O3 -g3 -o treePL $(OBJS) $(LIBS)
+	$(CP) $(LDFLAGS) -O3 -g3 -o treePL $(OBJS) $(LIBS)
 
 clean:
 	-$(RM) *.d *.o treePL
@@ -86,7 +86,7 @@ distclean:
 
 install:
 	install -m 0755 treePL $(prefix)
-	
+
 uninstall:
 	-rm $(prefix)treePL
 


### PR DESCRIPTION
Dear treePL developers,

trying to install treePL without root privileges, I noticed that setting the environment variables `CFLAGS`, `CPPFLAGS` and `LDFLAGS` had no effect. Therefore, the installation fails when `nlopt` and `adol-c` are in non-standard locations. This commit should fix this. My editor complained about "suspicious line" 86, I therefore replaced it with a blank line.

I would kindly like to ask you to consider merging this commit, since it makes it much easier to install treePL on for instance HPC infrastructures. 

Best,
Hannes