### PR TITLE
Honor configure options better

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -11,13 +11,13 @@ OPENMP := -fopenmp
 #OPENMP := -openmp -parallel
 
 LIBS := -lm $(OPENMP) -ladolc -lnlopt -L/usr/lib64:/usr/local/lib64
-LDFLAGS := -L/usr/local/lib64 -I/usr/local/include
+LDFLAGS := @LDFLAGS@ -L/usr/local/lib64 -I/usr/local/include
 
 RM := rm -rf
 
 SRC_DIR = ./
 
-prefix = /usr/bin/
+prefix = @prefix@
 
 CPP_SRCS += \
 ./main.cpp \
@@ -86,8 +86,8 @@ distclean:
 	-$(RM) *.o *.d configure config.log config.h config.status treePL Makefile
 
 install:
-	install -m 0755 treePL $(prefix)
+	install -Dm 0755 treePL $(prefix)/bin/treePL
 
 uninstall:
-	-rm $(prefix)treePL
+	-rm $(prefix)/bin/treePL
 


### PR DESCRIPTION
I encountered a problem building from source and using a non-standard path. (Specifically, this was building on an HPC system without root/sudo.) The build would fail because the makefile was ignoring `$LDFLAGS` from the environment and failing to find `nlopt` and `adolc`. 

Additionally, the makefile was setting the install prefix staticly rather than accepting the value from `./configure --prefix=something`.

The proposed changes use the `prefix` value provided by `./configure` (and use it more like standard unix/linux conventions) and also include the `$LDFLAGS` value from the environment.